### PR TITLE
Refactor 'current_nonce' fetching

### DIFF
--- a/scripts/_template_script.py
+++ b/scripts/_template_script.py
@@ -19,8 +19,8 @@ def main():
 
     # combine history into multisend txn
     # TODO: set 'safe_nonce' 
-    safe_tx.current_nonce = fetch_current_nonce(multisig)
     safe_tx = multisig.multisend_from_receipts()
+    safe_tx.current_nonce = fetch_current_nonce(multisig)
     safe_nonce = 47
     
     safe_tx.safe_nonce = safe_nonce

--- a/scripts/_template_script.py
+++ b/scripts/_template_script.py
@@ -2,7 +2,7 @@ from helpers import CHAIN_IDS, MULTISIG_ADDRESSES
 from ape_safe import ApeSafe
 from brownie import accounts, network
 
-from scripts.utils import confirm_posting_transaction
+from scripts.utils import confirm_posting_transaction, fetch_current_nonce
 
 def main():
     """DESCRIPTION OF WHAT THIS SCRIPT DOES"""
@@ -18,9 +18,10 @@ def main():
     """
 
     # combine history into multisend txn
-    # TODO: set nonce 
+    # TODO: set 'safe_nonce' 
+    safe_tx.current_nonce = fetch_current_nonce(multisig)
     safe_tx = multisig.multisend_from_receipts()
-    safe_nonce = 0
+    safe_nonce = 47
     
     safe_tx.safe_nonce = safe_nonce
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -3,9 +3,7 @@ from ape_safe import ApeSafe
 from gnosis.safe.safe_tx import SafeTx
 from brownie import Contract
 
-def confirm_posting_transaction(safe: ApeSafe, safe_tx: SafeTx):
-    safe_nonce = safe_tx.safe_nonce
-
+def fetch_current_nonce(safe: ApeSafe):
     # small abi of safe, only to be able to check nonce
     nonce_abi = [{
         "stateMutability": "view",
@@ -19,8 +17,13 @@ def confirm_posting_transaction(safe: ApeSafe, safe_tx: SafeTx):
                 }
         ]
     }]
+    return Contract.from_abi("GnosisSafeProxy", safe.address, nonce_abi).nonce()
 
-    current_nonce = Contract.from_abi("GnosisSafeProxy", safe.address, nonce_abi).nonce()
+
+def confirm_posting_transaction(safe: ApeSafe, safe_tx: SafeTx):
+    safe_nonce = safe_tx.safe_nonce
+
+    current_nonce = safe_tx.current_nonce
     pending_nonce = safe.pending_nonce()
     
     # check if nonce is invalid or already in use


### PR DESCRIPTION
Fixing wrong 'curent_nonce' return by fetching it previous to 'multisend_from_receipts()'